### PR TITLE
Issue #12: Update hook should not add previously added db column.

### DIFF
--- a/honeypot.install
+++ b/honeypot.install
@@ -130,10 +130,12 @@ function honeypot_update_1001() {
  * Adds the 'hostname' column to the {honeypot_user} table.
  */
 function honeypot_update_1002() {
-  $schema = honeypot_schema();
-  $spec = $schema['honeypot_user']['fields']['hostname'];
-  $spec['initial'] = '';
-  db_add_field('honeypot_user', 'hostname', $spec);
+  if (!db_field_exists('honeypot_user', 'hostname')) {
+    $schema = honeypot_schema();
+    $spec = $schema['honeypot_user']['fields']['hostname'];
+    $spec['initial'] = '';
+    db_add_field('honeypot_user', 'hostname', $spec);
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/backdrop-contrib/honeypot/issues/12
